### PR TITLE
Add hosts file check

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,18 @@ const DiscordRPC = require('discord-rpc'),
 
 const keys = require('./keys.json');
 
+/**
+ * Check if user is blocking open.spotify.com before establishing RPC connection
+ * Works only on Linux based systems that use /etc/hosts, if not this not provided
+ * user will be in loop of ECONNRESET [changed address]:80 or recieve false data.
+ **/
+function checkHosts (file) {
+  if (file.includes("open.spotify.com")) throw new Error("Arr' yer be pirating, please remove \"open.spotify.com\" rule from your hosts file.");
+}
+if (process.platform !== "win32") {
+      if (fs.existsSync("/etc/hosts")) checkHosts(fs.readFileSync("/etc/hosts", "utf-8"));
+}
+
 const rpc = new DiscordRPC.Client({ transport: keys.rpcTransportType }),
       s = new spotifyWeb.SpotifyWebHelper(),
       appClient = keys.appClientID,


### PR DESCRIPTION
Add hosts file check for Linux to prevent ECONNRESET loop on a local address (mainly used by pirates who try to circumvent ads), this throws an error at them saying they shouldn't pirate for this to work perfectly.

NOTE: This is neccesary, as there are people who legitimately copy a list of addresses to block into their hosts file, which include open.spotify.com. The console does NOT specify that "oh open.spotify.com is a local address" or whatever, it is usually up to the user to diagnose that, this should fix it.