### PR TITLE
Checking if the res and res.track is defined

### DIFF
--- a/app.js
+++ b/app.js
@@ -56,6 +56,7 @@ async function checkSpotify() {
       return;
     }
 
+    if (!res || !res.track) return;
     if (!res.track.track_resource || !res.track.artist_resource) return;
 
     if (currentSong.uri && res.track.track_resource.uri == currentSong.uri && (res.playing != currentSong.playing)) {


### PR DESCRIPTION
Added to the undefined checking so it doesn't error if res or res.track is not defined.